### PR TITLE
fix EXC_BAD_ACCESS crash after set dispatchDrawQueue

### DIFF
--- a/Graver/AsyncDraw/Base/WMGAsyncDrawView.h
+++ b/Graver/AsyncDraw/Base/WMGAsyncDrawView.h
@@ -40,7 +40,7 @@ typedef void(^WMGAsyncDrawCallback)(BOOL drawInBackground);
 @property (nonatomic, assign) BOOL reserveContentsBeforeNextDrawingComplete;
 
 // 用于异步绘制的队列，为nil时将使用GCD的global queue进行绘制，默认为nil
-@property (nonatomic, assign) dispatch_queue_t dispatchDrawQueue;
+@property (nonatomic, strong) dispatch_queue_t dispatchDrawQueue;
 
 // 异步绘制时global queue的优先级，默认优先级为DEFAULT。在设置了drawQueue时此参数无效。
 @property (nonatomic, assign) dispatch_queue_priority_t dispatchPriority;


### PR DESCRIPTION
美团的技术同学们：
你们好！惊叹于你们能将如此高效的 UI 渲染框架进行开源，十分感谢你们对开源事业做出的贡献，我也仔细阅读了Graver的源码，感觉学到了很多知识，我也非常希望能为Graver做出一点小小的贡献，我在测试的过程中，在设置异步绘制的队列时，发现会抛出野指针异常，导致崩溃，希望你们抽出时间能查阅一下，辛苦了，谢谢了！如需要进一步沟通，欢迎加我微信ruiwendelll，谢谢了！

### 问题复现
在DemoOrderListViewController中，#import "DemoOrderListCell.h"后，并且增加以下三行代码设置异步渲染队列，在代码运行时，点击进入订单页会导致抛出EXC_BAD_ACCESS异常，导致崩溃
![image](https://user-images.githubusercontent.com/16741621/51021978-f8e0e000-15bd-11e9-8f53-d1440bd2b9fa.png)
![image](https://user-images.githubusercontent.com/16741621/51023343-ad303580-15c1-11e9-9ddd-1f44db69f602.png)
而当我将dispatchDrawQueue使用strong而不是assign来修饰时，不会抛出EXC_BAD_ACCESS异常，导致崩溃。

### 原因
我在WMGAsyncDrawView.m中发现是使用assign修饰dispatch_queue_t类型的dispatchDrawQueue属性
![image](https://user-images.githubusercontent.com/16741621/51023168-34c97480-15c1-11e9-8a28-2ba785973836.png)

而我在Xcode对于dispatch的相关文档中发现，dispatch_queue_t是一个Objective-C对象类型，应该使用Strong来修饰
![image](https://user-images.githubusercontent.com/16741621/51021772-77894d80-15bd-11e9-93a0-a64fe88072b9.png)
译文：
在编译时，dispatch对象是被声明为Objective-C类型的，这样可以让他们遵循ARC的规则，以便于Block在运行时管理内存和使用静态分析器分析内存泄露，并且使它们可以加入到Cocoa框架中去”
简单来说，也就是dispatchDrawQueue是一个Objective-C对象类型，当使用assign来修饰时，不会使得指向对象引用计数增加，当再次访问这个属性时，此时对象可能已经被销毁，抛出野指针异常。

### Demo测试
Example2：
我自己写了一个测试Demo专门测试这个问题，发现也是如此
```
@interface ViewController ()
@property (nonatomic, strong) dispatch_queue_t myQueueWithStrong;
@property (nonatomic, assign) dispatch_queue_t myQueueWithAssign;
@end

@implementation ViewController

- (void)viewDidLoad {
    [super viewDidLoad];
    [self setup];
//    [self runWithStrong];
    [self runWithAssign];
}
-(void)setup {
    dispatch_queue_t queue1 = dispatch_queue_create("com.SerialQueue", NULL);
    self.myQueueWithStrong = queue1;
    
    dispatch_queue_t queue2 = dispatch_queue_create("com.SerialQueue", NULL);
    self.myQueueWithAssign = queue2;
}
-(void)runWithStrong {
    dispatch_async(self.myQueueWithStrong, ^{
        NSLog(@"runWithStrong运行成功！");
    });
}
-(void)runWithAssign{
    dispatch_async(self.myQueueWithAssign, ^{
        NSLog(@"runWithAssign运行成功！");
    });
}
```
执行runWithStrong方法，可以成功打印
![image](https://user-images.githubusercontent.com/16741621/51022720-f5e6ef00-15bf-11e9-91e9-3ec79ca77b16.png)


执行runWithAssign方法，则会抛出EXC_BAD_ACCESS异常
![image](https://user-images.githubusercontent.com/16741621/51022682-e1a2f200-15bf-11e9-808e-408b43774863.png)




